### PR TITLE
Import fix in pp

### DIFF
--- a/mcrl2/trans/pp.str
+++ b/mcrl2/trans/pp.str
@@ -4,7 +4,7 @@ imports
 
   libstratego-gpp
   libspoofax/editor/refactoring/-
-  mcrl2/pp
+  mcrl2/syntax/pp
 
 rules
 


### PR DESCRIPTION
An import in module pp refers to a non-existing module mcrl2/pp, resulting in a failing build. Changing this import to mcrl2/syntax/pp fixes this.