### PR TITLE
Remove redundant syntax rule for Product

### DIFF
--- a/mcrl2/syntax/mcrl2/Sort.sdf3
+++ b/mcrl2/syntax/mcrl2/Sort.sdf3
@@ -24,8 +24,7 @@ context-free syntax //--- Sort expressions and sort declarations
   MCRL2-SortExpr          = <(<MCRL2-SortExpr>)> {bracket}
   MCRL2-SortExpr.Struct   = <struct <{MCRL2-ConstrDecl " | "}+>>
   MCRL2-SortExpr.Function = [[MCRL2-SortExpr] -> [MCRL2-SortExpr]] {right}
-  MCRL2-SortExpr.Product  = MCRL2-Product
-  MCRL2-Product = <<MCRL2-SortExpr> # <{MCRL2-SortExpr " # "}+>>
+  MCRL2-SortExpr.Product  = <<MCRL2-SortExpr> # <{MCRL2-SortExpr " # "}+>>
 
   MCRL2-SortProduct = MCRL2-SortExpr
 


### PR DESCRIPTION
The syntax definition for a product of sorts consist of two syntax rules, but I don't see why it is just one rule. In the current construction additional parentheses are needed to use Product. For example, now one has to write Product((Bool(), [Bool()])), but with this change one would have to write Product(Bool(), [Bool()]).