### PR TITLE
Syntax rule for conditional data expression

### DIFF
--- a/mcrl2/syntax/mcrl2/Data.sdf3
+++ b/mcrl2/syntax/mcrl2/Data.sdf3
@@ -58,6 +58,7 @@ context-free syntax //--- Data expressions
   MCRL2-DataExpr.EltAt           = <<MCRL2-DataExpr> . <MCRL2-DataExpr>> {left}
   MCRL2-DataExpr.Where           = <<MCRL2-DataExpr> whr <{MCRL2-Assignment ", "}+> end> {left}
   MCRL2-DataExpr.As              = <<MCRL2-DataExpr> : <MCRL2-SortExpr>> /* extension */
+  MCRL2-DataExpr.Cond            = <if(<MCRL2-DataExpr>, <MCRL2-DataExpr>, <MCRL2-DataExpr>)
 
   MCRL2-Assignment.Assign = <<MCRL2-ID> = <MCRL2-DataExpr>>
 


### PR DESCRIPTION
The conditional data expression `if(b, c, d)` meaning "if b holds then c else d" is missing in the syntax definition. See the definition of this operator [here](https://mcrl2.org/web/user_manual/language_reference/data.html#predefined-mappings).

As this is a circumfix operator I expect that it is not necessary to define priorities for this operator.